### PR TITLE
Ufak düzeltmeler ve iyileştirmeler

### DIFF
--- a/src/llm/components/TocDiagram.tsx
+++ b/src/llm/components/TocDiagram.tsx
@@ -135,7 +135,7 @@ export const TocDiagram: React.FC<{
     entryGroups.push({ groupName: 'Bileşenler', entries: [] });
     makeEntry(Phase.Input_Detail_Embedding, 'Gömme (Embedding)', ['tokEmbed', 'posEmbed'], true);
     makeEntry(Phase.Input_Detail_LayerNorm, 'Katman Normu', ['ln1', 'ln2', 'lnf']);
-    makeEntry(Phase.Input_Detail_SelfAttention, 'Öz Dikkat', ['selfAttend']);
+    makeEntry(Phase.Input_Detail_SelfAttention, 'Öz-Dikkat', ['selfAttend']);
     makeEntry(Phase.Input_Detail_Projection, 'Projeksiyon', ['selfAttend']);
     makeEntry(Phase.Input_Detail_Mlp, 'Çok Katmanlı Algılayıcı', ['feedForward']);
     makeEntry(Phase.Input_Detail_Transformer, 'Dönüştürücü', ['transformer']);

--- a/src/llm/walkthrough/Walkthrough.ts
+++ b/src/llm/walkthrough/Walkthrough.ts
@@ -96,7 +96,7 @@ export function initWalkthrough() {
             phases: [
                 { id: Phase.Input_Detail_Embedding, title: 'Gömme (Embedding)' },
                 { id: Phase.Input_Detail_LayerNorm, title: 'Katman Normu' },
-                { id: Phase.Input_Detail_SelfAttention, title: 'Öz Dikkat' },
+                { id: Phase.Input_Detail_SelfAttention, title: 'Öz-Dikkat' },
                 { id: Phase.Input_Detail_Projection, title: 'Projeksiyon' },
                 { id: Phase.Input_Detail_Mlp, title: 'Çok Katmanlı Algılayıcı' },
                 { id: Phase.Input_Detail_Transformer, title: 'Dönüştürücü' },

--- a/src/llm/walkthrough/Walkthrough02_Embedding.tsx
+++ b/src/llm/walkthrough/Walkthrough02_Embedding.tsx
@@ -21,8 +21,8 @@ export function walkthrough02_Embedding(args: IWalkthroughArgs) {
     wt.dimHighlightBlocks = [layout.idxObj, layout.tokEmbedObj, layout.posEmbedObj, layout.residual0];
 
     commentary(wt)`
-Daha önce, tokenlerin basit bir _lookup table_ kullanılarak nasıl bir tam sayı dizisine eşlendiğini görmüştük.
-Bu tam sayılar, the ${c_blockRef('_token indisleri_', state.layout.idxObj, DimStyle.TokenIdx)}, modelde gördüğümüz _ilk ve tek_ tam sayılardır.
+Daha önce, tokenlerin basit bir _başvuru tablosu_ kullanılarak nasıl bir tam sayı dizisine eşlendiğini görmüştük.
+Bu tam sayılar, ${c_blockRef('_token indeksleri_', state.layout.idxObj, DimStyle.TokenIdx)}, modelde gördüğümüz _ilk ve tek_ tam sayılardır.
 Bundan sonra her zaman ondalık sayılar olan floatları kullanıyoruz.
 
 Şimdi, 4. tokenin (indeksi 3) ${c_blockRef('_girdi gömme_', state.layout.residual0)}'mizin, 4'üncü sütun vektörünü üretmek için nasıl kullanıldığına bir göz atalım.`;
@@ -49,7 +49,7 @@ Bu, ${c_dimRef('_C_ = 48', DimStyle.C)} boyutunda bir sütun vektörü üretir, 
     commentary(wt)`
 Ve 4. _pozisyonda_ (t = ${c_dimRef('3', DimStyle.T)}) olduğumuz için ${c_str('B', DimStyle.Token)} tokenimize bakarken, ${c_blockRef('_pozisyon gömme matrisi_', state.layout.posEmbedObj)}'nin 4. sütununu alacağız.
 
-Bu da aynı şekilde ${c_dimRef('_C_ = 48', DimStyle.C)} boyutunda bir sütun vektörü üretir, bunu _pozisyon gömmesi_ olarak tanımlıyoruz.
+Bu da aynı şekilde ${c_dimRef('_C_ = 48', DimStyle.C)} boyutunda bir sütun vektörü üretir, bunu _pozisyon gömmesi_ olarak tanımlıyoruz.
     `;
     breakAfter();
 

--- a/src/llm/walkthrough/Walkthrough03_LayerNorm.tsx
+++ b/src/llm/walkthrough/Walkthrough03_LayerNorm.tsx
@@ -75,7 +75,7 @@ ${c_blockRef('ağırlık (\u03b3)', ln.lnSigma)} ile çarpar ve ardından bir ${
     breakAfter();
     commentary(wt)`
 Bu normalleştirme işlemini ${c_blockRef('girdi gömme matrisi', layout.residual0)}'nin her bir sütununda uygularız ve bu sonuç,
-artık _Öz Dikkat_ katmanına geçirilmeye hazır olan ${c_blockRef('normalize edilmiş girdi gömmesi', ln.lnResid)}'dir.`;
+artık _Öz-Dikkat_ katmanına geçirilmeye hazır olan ${c_blockRef('normalize edilmiş girdi gömmesi', ln.lnResid)}'dir.`;
 
     breakAfter();
     let t_cleanupSplits = afterTime(null, 0.5);

--- a/src/llm/walkthrough/Walkthrough04_SelfAttention.tsx
+++ b/src/llm/walkthrough/Walkthrough04_SelfAttention.tsx
@@ -89,7 +89,7 @@ Peki bu Q (sorgu), K (anahtar) ve V (değer) vektörleriyle ne yaparız? Aslınd
 
 ${embedInline(<div className='ml-4'>
     <div className='mt-1 text-center italic'>Yazılım benzetmesi</div>
-    <div className='text-sm mt-1 mb-1 text-gray-600'>Lookup Tablosu:</div>
+    <div className='text-sm mt-1 mb-1 text-gray-600'>Başvuru tablosu:</div>
     <div className='font-mono'>{'table = { "key0": "value0", "key1": "value1", ... }'}</div>
     <div className='text-sm mt-1 mb-1 text-gray-600'>Sorgu Süreci:</div>
     <div className='font-mono'>{'table["key1"] => "value1"'}</div>
@@ -103,8 +103,8 @@ ${embedInline((() => {
     let qCol = dimStyleColor(DimStyle.Aggregates);
 
     return <div className='ml-4'>
-        <div className='mt-1 text-center italic'>Öz Dikkat</div>
-        <div className='text-sm mt-2 mb-1 text-gray-600'>Lookup tablosu:</div>
+        <div className='mt-1 text-center italic'>Öz-Dikkat</div>
+        <div className='text-sm mt-2 mb-1 text-gray-600'>Başvuru tablosu:</div>
         <div className='font-mono flex items-center'>K:
             <div className='mx-2 my-1'>{makeTextVector(keyCol)}</div>
             <div className='mx-2 my-1'>{makeTextVector(keyCol)}</div>
@@ -147,7 +147,7 @@ Daha somut bir örnek için, sorgu yapacağımız 6. sütuna (${c_dimRef('t = 5'
 // columns each have a K (key) vector, which represents the information that that column has, and our
 // Q (query) vector is what information is relevant to us.
     commentary(wt)`
-Lookup tablomuzdaki {K, V} girdileri geçmişteki 6 sütun, Q değeri ise şu anki zamandır.
+Başvuru tablomuzdaki {K, V} girdileri geçmişteki 6 sütun, Q değeri ise şu anki zamandır.
 
 İlk olarak, mevcut sütunun (${c_dimRef('t = 5', DimStyle.T)}) ${c_blockRef('Q vektörü', head2.qBlock)} ile önceki sütunların her birinin ${c_blockRef('K vektörleri', head2.kBlock)} arasında nokta çarpımını hesaplarız. Bunlar daha sonra ${c_blockRef('dikkat matrisi', head2.attnMtx)}'nin ilgili sırasına (${c_dimRef('t = 5', DimStyle.T)}) saklanır.`;
     breakAfter();


### PR DESCRIPTION
- Tutarlılık için bazı kelimelerin değiştirilmesi
- Artık `The` kelimesinin kaldırılması ([`src/llm/walkthrough/Walkthrough02_Embedding.tsx#L25`](https://github.com/f/llm-viz-tr/blob/5ebcae19dfc59a8e0e3edf600e0771abd209c339/src/llm/walkthrough/Walkthrough02_Embedding.tsx#L25))
- `lookup table/tablosu` yerine `başvuru tablosu` dönüşümü (tartışmaya açık, farklı bir şekilde de ele alınabilir.)
- `Whitespace` düzeltmesi